### PR TITLE
Keep spaces between strings and #defined constants.

### DIFF
--- a/src/filemap.cpp
+++ b/src/filemap.cpp
@@ -876,7 +876,7 @@ void filemapper_t::print(FILE *f, const char *ref)
 	while(k)
 	{
 		if(strcmp(k->key, key) == 0 || all)
-			fprintf(f, "%s"FM_DEREF_TOKEN" --> \"%s\"\n", k->key, k->path);
+			fprintf(f, "%s" FM_DEREF_TOKEN " --> \"%s\"\n", k->key, k->path);
 		k = k->next;
 	}
 }

--- a/src/prefs.cpp
+++ b/src/prefs.cpp
@@ -31,7 +31,7 @@
 void prefs_t::init()
 {
 	comment("------------------------------------------------");
-	comment(" Kobo Redux "KOBO_VERSION_STRING" Configuration File");
+	comment(" Kobo Redux " KOBO_VERSION_STRING " Configuration File");
 	comment("------------------------------------------------");
 	comment(" Switches - [no]<switch> or <switch> [<value>]");
 	comment(" Values - <key> [<value>|\"<string>\"]");


### PR DESCRIPTION
clang-6.0.0 on OpenBSD:

    error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]